### PR TITLE
Update to 0.3.pre (HEAD). Remove rpaths. Pin arrow-cpp/parquet-cpp dependencies

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,5 +9,5 @@ export PARQUET_HOME=$PREFIX
 
 cd python
 $PYTHON setup.py \
-        build_ext --build-type=release --with-parquet \
+        build_ext --build-type=release --with-parquet --with-jemalloc \
         install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.2.post" %}
-{% set commit = "f6924ad83bc95741f003830892ad4815ca3b70fd" %}
+{% set version = "0.3.pre" %}
+{% set commit = "0dc6fe8f33befaaa5fc8055b6c157ac1ccb09e6b" %}
 
 package:
   name: pyarrow
@@ -8,13 +8,10 @@ package:
 source:
   fn: {{ commit }}.tar.gz
   url: https://github.com/apache/arrow/archive/{{ commit }}.tar.gz
-  sha256: d78fcb18284ce043f3375096deaed83ff491c95237e9ba3ec5349a1c760fb14b
+  sha256: 98770adee18c058202e21a6b218c2ea40214ddc52e57472750ec71c5428de5ca
 
 build:
   number: 0
-  rpaths:
-    - lib  # [unix]
-    - lib/python{{ environ['PY_VER'] }}/site-packages/pyarrow  # [unix]
   skip: true  # [win]
 
 requirements:
@@ -23,21 +20,21 @@ requirements:
     - toolchain
     - setuptools
     - setuptools_scm
-    - arrow-cpp 0.2.*
     - cython
     - cmake
     - numpy x.x
     - six
-    - parquet-cpp
+    - arrow-cpp 0.3.*
+    - parquet-cpp 1.1.*
 
   run:
     - python
     - setuptools
-    - arrow-cpp
     - numpy x.x
     - pandas
-    - parquet-cpp
     - six
+    - arrow-cpp 0.3.*
+    - parquet-cpp 1.1.*
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ requirements:
 test:
   imports:
     - pyarrow
-    - pyarrow.jemalloc  # [unix]
-    - pyarrow.parquet   # [unix]
+    - pyarrow._jemalloc  # [unix]
+    - pyarrow.parquet    # [unix]
 
 about:
   home: http://github.com/apache/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - numpy x.x
     - six
     - arrow-cpp 0.3.*
-    - parquet-cpp 1.1.*
+    - parquet-cpp 1.1.*  # [unix]
 
   run:
     - python
@@ -34,14 +34,13 @@ requirements:
     - pandas
     - six
     - arrow-cpp 0.3.*
-    - parquet-cpp 1.1.*
+    - parquet-cpp 1.1.*  # [unix]
 
 test:
   imports:
     - pyarrow
-    - pyarrow.io
-    - pyarrow.ipc
-    - pyarrow.parquet
+    - pyarrow.jemalloc  # [unix]
+    - pyarrow.parquet   # [unix]
 
 about:
   home: http://github.com/apache/arrow


### PR DESCRIPTION
Closes #18, closes #21 