### PR TITLE
Add ORC support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,5 +10,5 @@ export PARQUET_HOME=$PREFIX
 
 cd python
 $PYTHON setup.py \
-        build_ext --build-type=release --with-parquet --with-plasma \
+        build_ext --build-type=release --with-parquet --with-plasma --with-orc \
         install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
   skip: true  # [win and py<35]
   features:


### PR DESCRIPTION
Changes the non-windows build script to build optional ORC reader
support. This is unsupported currently on windows, so no need to change
the windows build script.