### PR TITLE
Pin boost-cpp directly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
-    # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
     # Add path, activate `conda` and update conda.
@@ -37,14 +37,9 @@ install:
 
     - cmd: set PYTHONUNBUFFERED=1
 
-    # Add our channels.
-    - cmd: conda.exe config --set show_channel_urls true
-    - cmd: conda.exe config --remove channels defaults
-    - cmd: conda.exe config --add channels defaults
-    - cmd: conda.exe config --add channels conda-forge
-
     # Configure the VM.
-    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=2
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2
+    - cmd: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -1,0 +1,28 @@
+jobs:
+- job: linux_64
+  pool:
+    vmImage: ubuntu-16.04
+  timeoutInMinutes: 240
+  strategy:
+    maxParallel: 8
+    matrix:
+      linux_c_compilergcccxx_compilergxxpython2.7:
+        CONFIG: linux_c_compilergcccxx_compilergxxpython2.7
+      linux_c_compilergcccxx_compilergxxpython3.6:
+        CONFIG: linux_c_compilergcccxx_compilergxxpython3.6
+      linux_c_compilergcccxx_compilergxxpython3.7:
+        CONFIG: linux_c_compilergcccxx_compilergxxpython3.7
+      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7:
+        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7
+      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6:
+        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6
+      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7:
+        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7
+  steps:
+  - script: |
+      sudo pip install --upgrade pip
+      sudo pip install setuptools shyaml
+    displayName: Install dependencies
+
+  - script: .azure-pipelines/run_docker_build.sh
+    displayName: Run docker build

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,84 @@
+jobs:
+- job: osx_64
+  pool:
+    vmImage: macOS-10.13
+  timeoutInMinutes: 240
+  strategy:
+    maxParallel: 8
+    matrix:
+      osx_c_compilerclangcxx_compilerclangxxpython2.7:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxpython2.7
+      osx_c_compilerclangcxx_compilerclangxxpython3.6:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxpython3.6
+      osx_c_compilerclangcxx_compilerclangxxpython3.7:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxpython3.7
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      echo "Fast Finish"
+      
+
+  - script: |
+      echo "Removing homebrew from Azure to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+    displayName: Remove homebrew
+
+  - script: |
+      echo "Installing Miniconda"
+      set -x -e
+      curl -o $(Build.StagingDirectory)/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+      chmod +x $(Build.StagingDirectory)/miniconda.sh
+      $(Build.StagingDirectory)/miniconda.sh -b -p $(Build.StagingDirectory)/miniconda
+      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      echo "Setting up Conda environment"
+    displayName: 'Install miniconda'
+
+  - script: |
+      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      set -x -e
+      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2
+    displayName: 'Add conda-forge-ci-setup=2'
+
+  - script: |
+      set -x -e
+      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      echo "Configuring conda."
+
+      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+      source run_conda_forge_build_setup
+      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+    env: {
+      OSX_FORCE_SDK_DOWNLOAD: "1"
+    }
+    displayName: Configure conda and conda-build
+
+  - script: |
+      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      set -x -e
+      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Mangle compiler
+
+  - script: |
+      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      set -x -e
+      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Generate build number clobber file
+
+  - script: |
+      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      set -x -e
+      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+    displayName: Build recipe
+
+  

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,88 @@
+jobs:
+- job: win_64
+  pool:
+    vmImage: vs2017-win2016
+  timeoutInMinutes: 240
+  strategy:
+    maxParallel: 4
+    matrix:
+      win_c_compilervs2015cxx_compilervs2015python3.6:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.6
+        CONDA_BLD_PATH: D:\\bld\\
+      win_c_compilervs2015cxx_compilervs2015python3.7:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.7
+        CONDA_BLD_PATH: D:\\bld\\
+  steps:
+    # TODO: Fast finish on azure pipelines?
+    - script: |
+        ECHO ON
+        
+
+    - script: |
+        choco install vcpython27 -fdv -y --debug
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Install vcpython27.msi (if needed)
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # - script: rmdir C:\cygwin /s /q
+    #   continueOnError: true
+
+
+    - powershell: |
+        Set-PSDebug -Trace 1
+
+        $batchcontent = @"
+        ECHO ON
+        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
+
+        DIR "%vcpython%"
+
+        CALL "%vcpython%\vcvarsall.bat" %*
+        "@
+
+        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
+        $batchPath = "$batchDir" + "\vcvarsall.bat"
+        New-Item -Path $batchPath -ItemType "file" -Force
+
+        Set-Content -Value $batchcontent -Path $batchPath
+
+        Get-ChildItem -Path $batchDir
+
+        Get-ChildItem -Path ($batchDir + '\..')
+
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Patch vs2008 (if needed)
+
+    - task: CondaEnvironment@1
+      inputs:
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        installOptions: "-c conda-forge"
+        updateConda: false
+      displayName: Install conda-build and activate environment
+
+    - script: set PYTHONUNBUFFERED=1
+
+    # Configure the VM
+    - script: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
+    
+    # Configure the VM.
+    - script: |
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+    run_conda_forge_build_setup
+
+    # Special cased version setting some more things!
+    - script: |
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+      displayName: Build recipe (vs2008)
+      env: {
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",
+      }
+      condition: contains(variables['CONFIG'], 'vs2008')
+
+    - script: |
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+      displayName: Build recipe
+      condition: not(contains(variables['CONFIG'], 'vs2008'))
+
+    

--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -27,16 +27,12 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-source run_conda_forge_build_setup
-
-# make the build number clobber
+run_conda_forge_build_setup# make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
-
-upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -38,8 +38,8 @@ DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-v
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
-# Enable running in interactive mode attached to a tty
-DOCKER_RUN_ARGS=" -it "
+# Not all providers run with a real tty.  Disable using one
+DOCKER_RUN_ARGS=" "
 
 
 docker run ${DOCKER_RUN_ARGS} \

--- a/.ci_support/linux_c_compilergcccxx_compilergxxpython2.7.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxpython2.7.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '0'
 c_compiler:
@@ -11,6 +13,8 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil-comp7
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilergcccxx_compilergxxpython3.6.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxpython3.6.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '0'
 c_compiler:
@@ -11,6 +13,8 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil-comp7
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilergcccxx_compilergxxpython3.7.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxpython3.7.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '0'
 c_compiler:
@@ -11,6 +13,8 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil-comp7
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '1000'
 c_compiler:
@@ -11,6 +13,8 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '1000'
 c_compiler:
@@ -11,6 +13,8 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '1000'
 c_compiler:
@@ -11,6 +13,8 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxpython2.7.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxpython2.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '0'
 c_compiler:
@@ -15,6 +17,8 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxpython3.6.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxpython3.6.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '0'
 c_compiler:
@@ -15,6 +17,8 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxpython3.7.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxpython3.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '0'
 c_compiler:
@@ -15,6 +17,8 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython2.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '1000'
 c_compiler:
@@ -15,6 +17,8 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.6.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '1000'
 c_compiler:
@@ -15,6 +17,8 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxpython3.7.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+boost_cpp:
+- 1.68.0
 build_number_decrement:
 - '1000'
 c_compiler:
@@ -15,6 +17,8 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 c_compiler:
 - vs2015
 channel_sources:
@@ -7,6 +9,8 @@ channel_targets:
 cxx_compiler:
 - vs2015
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -1,3 +1,5 @@
+boost_cpp:
+- 1.68.0
 c_compiler:
 - vs2015
 channel_sources:
@@ -7,6 +9,8 @@ channel_targets:
 cxx_compiler:
 - vs2015
 pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@
 language: generic
 
 os: osx
-osx_image: xcode6.4
+osx_image: xcode9.4
+
 
 env:
   matrix:
@@ -52,7 +53,7 @@ install:
       echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
 
-      conda install --yes --quiet conda-forge::conda-forge-ci-setup=2
+      conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2
       setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
       source run_conda_forge_build_setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 About pyarrow
 =============
 
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+
 Home: http://github.com/apache/arrow
 
 Package license: Apache 2.0
@@ -104,3 +106,18 @@ In order to produce a uniquely identifiable distribution:
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.
+
+Feedstock Maintainers
+=====================
+
+* [@cpcloud](https://github.com/cpcloud/)
+* [@jreback](https://github.com/jreback/)
+* [@kou](https://github.com/kou/)
+* [@kszucs](https://github.com/kszucs/)
+* [@pcmoritz](https://github.com/pcmoritz/)
+* [@pitrou](https://github.com/pitrou/)
+* [@robertnishihara](https://github.com/robertnishihara/)
+* [@siddharthteotia](https://github.com/siddharthteotia/)
+* [@wesm](https://github.com/wesm/)
+* [@xhochy](https://github.com/xhochy/)
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,10 @@
+jobs:
+  - template: ./.azure-pipelines/azure-pipelines-linux.yml
+
+  
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml
+
+  
+  - template: ./.azure-pipelines/azure-pipelines-win.yml
+
+  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    # directly pin boost-cpp as we also seem to directly include boost symbols
+    # in the Python modules.
     - boost-cpp
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 1000
+  number: 1001
   skip: true  # [win32]
   skip: true  # [win and py<35]
 
@@ -22,6 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - boost-cpp
     - python
     - setuptools
     - setuptools_scm
@@ -31,6 +32,7 @@ requirements:
     - arrow-cpp {{ version }}
 
   run:
+    - boost-cpp
     - python
     - setuptools
     - {{ pin_compatible('numpy', lower_bound='1.14') }}


### PR DESCRIPTION
We seem to also link some boost symbols into pyarrow. This should guarantee through the new `run_exports` pinning mechanism that we only see installs of arrow-cpp and pyarrow with the same `boost-cpp` version.

This sadly does not fix the issue with boost-cpp and libboost.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
