### PR TITLE
Removed setuptools from conda run dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
   run:
     - boost-cpp
     - python
-    - setuptools
     - {{ pin_compatible('numpy', lower_bound='1.14') }}
     - pandas
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
   skip: true  # [win and py<35]
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pyarrow-feedstock/issues/75
`setuptools` package should not be run dependency for pyarrow conda package.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.




