### PR TITLE
Bump the NumPy pin in preparation for aarch64 and ppc64le builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win32]
   skip: true  # [win and py<35]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - arrow-cpp {{ version }}
     - boost-cpp
     - cython
-    - numpy 1.14.*
+    - numpy 1.16.*
     - python
     - setuptools
     - setuptools_scm
@@ -36,7 +36,7 @@ requirements:
 
   run:
     - {{ pin_compatible('arrow-cpp') }}
-    - {{ pin_compatible('numpy', lower_bound='1.14') }}
+    - {{ pin_compatible('numpy', lower_bound='1.16') }}
     - boost-cpp
     - futures  # [py==27]
     - glog


### PR DESCRIPTION
This is analogous to PR ( https://github.com/conda-forge/arrow-cpp-feedstock/pull/99 ) except for `pyarrow` instead.

In preparation for building this feedstock for aarch64 and ppc64le, bump the `numpy` minimum version to 1.16, which is the version we have built on those architectures. It was found to be too difficult to build earlier versions on those architectures; so, the minimum `numpy` version was bumped to the oldest version that could reasonably be built.

ref: https://github.com/conda-forge/numpy-feedstock/pull/136#issuecomment-510785440

cc @xhochy

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->