### PR TITLE
test skip hyghiene: remove skips for tests that now pass 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -287,10 +287,8 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or test_debug_memory_pool_disabled" %}   # [aarch64 or ppc64le]
         {% set tests_to_skip = tests_to_skip + " or test_env_var_io_thread_count" %}      # [aarch64 or ppc64le]
         # vvvvvvv TESTS THAT SHOULDN'T HAVE TO BE SKIPPED vvvvvvv
-        # problems with minio
-        {% set tests_to_skip = tests_to_skip + " or (test_delete_dir and S3FileSystem)" %}
-        {% set tests_to_skip = tests_to_skip + " or (test_get_file_info and S3FileSystem)" %}
-        {% set tests_to_skip = tests_to_skip + " or (test_move_directory and S3FileSystem)" %}
+        # https://github.com/apache/arrow/issues/43800
+        {% set tests_to_skip = tests_to_skip + " or test_cpp_extension_in_python" %}                # [osx]
         # XMinioInvalidObjectName on win: "Object name contains unsupported characters"
         {% set tests_to_skip = tests_to_skip + " or test_write_to_dataset_with_partitions_s3fs" %}  # [win]
         # https://github.com/apache/arrow/issues/43356
@@ -302,9 +300,6 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or test_feather_format[serial]" %}                 # [aarch64]
         # gandiva tests are segfaulting on ppc
         {% set tests_to_skip = tests_to_skip + " or test_gandiva" %}                                # [ppc64le]
-        # test failures on ppc (both failing with: Float value was truncated converting to int32)
-        {% set tests_to_skip = tests_to_skip + " or test_safe_cast_from_float_with_nans_to_int" %}  # [ppc64le]
-        {% set tests_to_skip = tests_to_skip + " or test_float_with_null_as_integer" %}             # [ppc64le]
         # ^^^^^^^ TESTS THAT SHOULDN'T HAVE TO BE SKIPPED ^^^^^^^
         - pytest pyarrow/ -rfEs -k "not ({{ tests_to_skip }})"
 


### PR DESCRIPTION
On the occasion of a new failure on osx for the [15.x](https://github.com/conda-forge/arrow-cpp-feedstock/pull/1512) & [14.x](https://github.com/conda-forge/arrow-cpp-feedstock/pull/1513) builds that are still on the arrow-cpp feedstock.